### PR TITLE
feat: introduce queue worker with retries

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -18,6 +18,9 @@ class Settings(BaseSettings):
 
     PRESETS_FILE: str = "./presets.yaml"
 
+    REDIS_URL: str = "redis://localhost:6379/0"
+    QUEUE_STREAM: str = "presets"
+
     model_config = SettingsConfigModel = SettingsConfigDict(env_file='.env', extra='ignore')
 
 class PresetItem(BaseModel):

--- a/app/main.py
+++ b/app/main.py
@@ -2,10 +2,12 @@ import asyncio
 from .db import init_db
 from .orchestrator import Orchestrator
 from .config import settings
+from .queue import RedisQueue
 
 async def main():
     await init_db()
-    orch = Orchestrator()
+    queue = RedisQueue(settings.REDIS_URL, settings.QUEUE_STREAM)
+    orch = Orchestrator(queue)
     await orch.start()
 
     print("Orchestrator started. Hourly scraping + 09:00/19:00 digests enabled.")

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -1,21 +1,16 @@
 import asyncio
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
-from sqlalchemy.ext.asyncio import AsyncSession
-from .db import SessionLocal
 from .config import settings, presets
-from .scraper.render import RenderService
-from .processing.pipeline import process_preset
-from .notifier.bot import send_batch
+from .queue import AbstractQueue
 
 class Orchestrator:
-    def __init__(self):
-        self.render = RenderService()
+    def __init__(self, queue: AbstractQueue):
+        self.queue = queue
         self.scheduler = AsyncIOScheduler()
         self.running = False
 
     async def start(self):
-        await self.render.start()
         self.running = True
 
         # План: каждый час тихий сбор + подборки в 09:00 и 19:00
@@ -25,38 +20,39 @@ class Orchestrator:
 
     async def stop(self):
         self.scheduler.shutdown(wait=False)
-        await self.render.stop()
         self.running = False
 
     async def run_all_presets_no_notify(self):
-        async with SessionLocal() as session:
-            await self._run_presets(session, notify=False)
+        await self._run_presets(notify=False)
 
     async def run_all_presets_and_notify(self):
-        async with SessionLocal() as session:
-            await self._run_presets(session, notify=True)
+        await self._run_presets(notify=True)
 
-    async def _run_presets(self, session: AsyncSession, notify: bool):
+    async def _run_presets(self, notify: bool):
         geoid = presets.geoid_default or settings.DEFAULT_GEOID
         min_discount = settings.MIN_DISCOUNT
         min_score = settings.MIN_SCORE
 
-        all_results: list[dict] = []
-
         # ozon
         for item in presets.sites.get("ozon", []):
-            res = await process_preset(session, self.render, "ozon", item["url"], None, min_discount, min_score)
-            all_results.extend(res)
+            await self.queue.publish({
+                "site": "ozon",
+                "url": item["url"],
+                "geoid": "",
+                "min_discount": min_discount,
+                "min_score": min_score,
+                "notify": notify,
+            })
             await asyncio.sleep(1.0)
 
         # market
         for item in presets.sites.get("market", []):
-            res = await process_preset(session, self.render, "market", item["url"], geoid, min_discount, min_score)
-            all_results.extend(res)
+            await self.queue.publish({
+                "site": "market",
+                "url": item["url"],
+                "geoid": geoid,
+                "min_discount": min_discount,
+                "min_score": min_score,
+                "notify": notify,
+            })
             await asyncio.sleep(1.0)
-
-        # Отправка батчем — если включён фиксированный чат
-        if notify and settings.TG_CHAT_ID and all_results:
-            # ограничим размер подборки 20 лучших
-            best = sorted(all_results, key=lambda x: x["score"], reverse=True)[:20]
-            await send_batch(settings.TELEGRAM_BOT_TOKEN, settings.TG_CHAT_ID, best)

--- a/app/queue/__init__.py
+++ b/app/queue/__init__.py
@@ -1,0 +1,54 @@
+import asyncio
+from typing import Callable, Awaitable, Any
+import redis.asyncio as redis
+
+
+class PermanentError(Exception):
+    """Исключение для ошибок, которые не стоит ретраить."""
+    pass
+
+
+class AbstractQueue:
+    async def publish(self, data: dict, dlq: bool = False) -> None:
+        raise NotImplementedError
+
+    async def consume(self, handler: Callable[[dict], Awaitable[Any]], consumer_name: str) -> None:
+        raise NotImplementedError
+
+
+class RedisQueue(AbstractQueue):
+    def __init__(self, url: str, stream: str):
+        self.redis = redis.from_url(url)
+        self.stream = stream
+        self.dlq_stream = f"{stream}:dlq"
+        self.last_id = "0-0"
+
+    async def publish(self, data: dict, dlq: bool = False) -> None:
+        stream = self.dlq_stream if dlq else self.stream
+        # redis streams хранят строки
+        payload = {k: str(v) for k, v in data.items()}
+        await self.redis.xadd(stream, payload)
+
+    async def consume(self, handler: Callable[[dict], Awaitable[Any]], consumer_name: str = "worker") -> None:
+        max_retries = 5
+        while True:
+            res = await self.redis.xread({self.stream: self.last_id}, block=1000, count=1)
+            if not res:
+                continue
+            for _stream, messages in res:
+                for msg_id, message in messages:
+                    data = {k.decode(): v.decode() for k, v in message.items()}
+                    retries = int(data.pop("retries", "0"))
+                    try:
+                        await handler(data)
+                    except PermanentError:
+                        await self.publish({**data, "retries": retries}, dlq=True)
+                    except Exception:
+                        if retries + 1 >= max_retries:
+                            await self.publish({**data, "retries": retries + 1}, dlq=True)
+                        else:
+                            await asyncio.sleep(2 ** retries)
+                            await self.publish({**data, "retries": retries + 1})
+                    finally:
+                        await self.redis.xdel(self.stream, msg_id)
+                        self.last_id = msg_id

--- a/app/worker.py
+++ b/app/worker.py
@@ -1,0 +1,46 @@
+import asyncio
+from .queue import RedisQueue, PermanentError
+from .processing.pipeline import process_preset
+from .scraper.render import RenderService
+from .db import SessionLocal
+from .config import settings
+from .notifier.bot import send_batch
+
+
+class Worker:
+    def __init__(self, queue: RedisQueue):
+        self.queue = queue
+        self.render = RenderService()
+
+    async def start(self):
+        await self.render.start()
+        await self.queue.consume(self.handle_task)
+
+    async def handle_task(self, task: dict):
+        site = task.get("site")
+        if site not in {"ozon", "market"}:
+            raise PermanentError(f"Unknown site {site}")
+        async with SessionLocal() as session:
+            results = await process_preset(
+                session,
+                self.render,
+                site,
+                task.get("url", ""),
+                task.get("geoid") or None,
+                int(task.get("min_discount", settings.MIN_DISCOUNT)),
+                int(task.get("min_score", settings.MIN_SCORE)),
+            )
+        notify = task.get("notify") in {"True", True}
+        if notify and settings.TG_CHAT_ID and results:
+            best = sorted(results, key=lambda x: x["score"], reverse=True)[:20]
+            await send_batch(settings.TELEGRAM_BOT_TOKEN, settings.TG_CHAT_ID, best)
+
+
+async def main():
+    queue = RedisQueue(settings.REDIS_URL, settings.QUEUE_STREAM)
+    worker = Worker(queue)
+    await worker.start()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ SQLAlchemy>=2.0.29
 aiosqlite>=0.20.0
 python-dotenv>=1.0.1
 APScheduler>=3.10.4
+redis>=5.0.0


### PR DESCRIPTION
## Summary
- add Redis-based queue with exponential retry and DLQ
- enqueue presets in orchestrator instead of direct processing
- create worker to process queue tasks and send results

## Testing
- `pytest`
