### PR TITLE
Расширена обработка истории цен и скоринг офферов

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -16,6 +16,11 @@ class Product(Base):
     finger: Mapped[str] = mapped_column(String(32), index=True)  # md5 fingerprint
     geoid_created: Mapped[str | None] = mapped_column(String(16))
 
+    avg_price_30d: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    min_price_30d: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    avg_price_90d: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    min_price_90d: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
     offers: Mapped[list["Offer"]] = relationship(back_populates="product", cascade="all, delete-orphan")
     history: Mapped[list["PriceHistory"]] = relationship(back_populates="product", cascade="all, delete-orphan")
 
@@ -36,6 +41,10 @@ class Offer(Base):
     price_in_cart: Mapped[bool | None] = mapped_column(Boolean)
     subscription: Mapped[bool | None] = mapped_column(Boolean)
     scraped_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, index=True)
+    discount_pct: Mapped[float | None] = mapped_column(Float, nullable=True)
+    abs_saving: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    fake_msrp: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
     product: Mapped["Product"] = relationship(back_populates="offers")
     __table_args__ = (

--- a/app/processing/score.py
+++ b/app/processing/score.py
@@ -8,7 +8,7 @@ def discount_pct(base: Optional[int], price_final: Optional[int]) -> Optional[fl
 def compute_score(disc_pct: Optional[float], abs_saving: Optional[int], seller_rating: Optional[float] = None, shipping_days: Optional[int] = None) -> float:
     dp = disc_pct or 0.0
     abs_s = (abs_saving or 0) / 100.0
-    sr = (seller_rating or 0)  # 0..5 → можно масштабировать, но оставим как есть
+    sr = (seller_rating or 0) * 20  # 0..5 → 0..100
     sd = -(shipping_days or 0)
-    # веса (игрушечные, можно тюнинговать)
-    return round(0.5*dp + 0.25*abs_s + 0.15*sr + 0.1*sd + 10, 2)
+    # новая формула: веса 0.4/0.3/0.2/0.1 и базовый сдвиг 10
+    return round(0.4*dp + 0.3*abs_s + 0.2*sr + 0.1*sd + 10, 2)


### PR DESCRIPTION
## Summary
- рассчитывать средние/минимальные цены за 30 и 90 дней
- помечать завышенный MSRP и сохранять метрики в таблицы
- обновлена формула итогового скоринга

## Testing
- `python -m py_compile app/models.py app/processing/pipeline.py app/processing/score.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab299421ec8332b94678f4c173576a