### PR TITLE
Добавлены селекторы из YAML и тесты парсинга листингов

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/app/scraper/adapters/__init__.py
+++ b/app/scraper/adapters/__init__.py
@@ -1,0 +1,16 @@
+from functools import lru_cache
+from pathlib import Path
+import yaml
+
+
+@lru_cache()
+def _load_selectors() -> dict:
+    path = Path(__file__).with_name("selectors.yaml")
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f) or {}
+
+
+def get_selectors(name: str) -> dict:
+    return _load_selectors().get(name, {})

--- a/app/scraper/adapters/ozon.py
+++ b/app/scraper/adapters/ozon.py
@@ -2,6 +2,7 @@ from bs4 import BeautifulSoup
 from urllib.parse import urljoin, urlparse
 import re
 from ...schemas import OfferRaw
+from . import get_selectors
 
 BASE = "https://www.ozon.ru"
 
@@ -20,8 +21,12 @@ def parse_listing(html: str) -> list[OfferRaw]:
     items: list[OfferRaw] = []
 
     # Ozon листинг часто живёт в data-widget="searchResultsV2"
-    container = soup.select_one('[data-widget="searchResultsV2"]') or soup
-    cards = container.select('a[href*="/product/"]')
+    selectors = get_selectors("ozon")
+    container_sel = selectors.get("container", '[data-widget="searchResultsV2"]')
+    card_sel = selectors.get("card", 'a[href*="/product/"]')
+
+    container = soup.select_one(container_sel) or soup
+    cards = container.select(card_sel)
     seen = set()
     for a in cards:
         href = a.get("href")

--- a/app/scraper/adapters/selectors.yaml
+++ b/app/scraper/adapters/selectors.yaml
@@ -1,0 +1,9 @@
+ozon:
+  container: '[data-widget="searchResultsV2"]'
+  card: 'a[href*="/product/"]'
+market:
+  card: "article[data-autotest-id='product-snippet']"
+  link: "a[href*='/product--']"
+  title: "[data-baobab-name='title']"
+  price: "[data-autotest-value]"
+  image: 'img'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv>=1.0.1
 APScheduler>=3.10.4
 redis>=5.0.0
 boto3>=1.34.0
+PyYAML>=6.0

--- a/tests/fixtures/market_listing.html
+++ b/tests/fixtures/market_listing.html
@@ -1,0 +1,12 @@
+<article data-autotest-id="product-snippet">
+  <a href="/product--slug1/111"></a>
+  <div data-baobab-name="title">Товар A</div>
+  <div data-autotest-value="1234"></div>
+  <img src="/img1.png" />
+</article>
+<article data-autotest-id="product-snippet">
+  <a href="/product--slug2/222"></a>
+  <div data-baobab-name="title">Товар B</div>
+  <div data-autotest-value="2345"></div>
+  <img src="/img2.png" />
+</article>

--- a/tests/fixtures/ozon_listing.html
+++ b/tests/fixtures/ozon_listing.html
@@ -1,0 +1,12 @@
+<div data-widget="searchResultsV2">
+  <a href="/product/123">
+    <span>Товар A</span>
+    <div>1 234 ₽</div>
+    <img src="/img1.jpg" />
+  </a>
+  <a href="/product/456">
+    <span>Товар B</span>
+    <div>2 345 ₽</div>
+    <img src="/img2.jpg" />
+  </a>
+</div>

--- a/tests/test_parse_listing.py
+++ b/tests/test_parse_listing.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.scraper.adapters.ozon import parse_listing as parse_ozon
+from app.scraper.adapters.market import parse_listing as parse_market
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def load(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def test_parse_listing_ozon():
+    html = load("ozon_listing.html")
+    items = parse_ozon(html)
+    assert len(items) == 2
+    first = items[0]
+    assert first.title.startswith("Товар A")
+    assert first.price == 1234
+    assert str(first.url).endswith("/product/123")
+    assert str(first.img).endswith("/img1.jpg")
+
+
+def test_parse_listing_market():
+    html = load("market_listing.html")
+    items = parse_market(html, geoid="213")
+    assert len(items) == 2
+    first = items[0]
+    assert first.title == "Товар A"
+    assert first.price == 1234
+    assert str(first.url).endswith("/product--slug1/111")
+    assert str(first.img).endswith("/img1.png")
+    assert first.geoid == "213"


### PR DESCRIPTION
## Изменения
- вынесены CSS-селекторы в `selectors.yaml` и подключены в адаптерах
- добавлены юнит-тесты на `parse_listing` для Ozon и Маркета
- настроен GitHub Actions для запуска `pytest`

## Проверка
- `pytest`

