### PR TITLE
Поддержка регионов и подписок

### DIFF
--- a/app/processing/normalize.py
+++ b/app/processing/normalize.py
@@ -28,10 +28,12 @@ def compute_final_price(
     price: Optional[int],
     promo_flags: Dict[str, int | bool] | None = None,
     shipping_days: Optional[int] = None,
+    subscription: bool = False,
+    price_in_cart: bool = False,
 ) -> Optional[int]:
-    """Высчитывает финальную цену с учётом купонов и доставки."""
+    """Высчитывает финальную цену с учётом купонов, доставки и подписки."""
 
-    if price is None:
+    if price is None or price_in_cart:
         return None
 
     coupon = 0
@@ -39,7 +41,7 @@ def compute_final_price(
         coupon = int(promo_flags.get("instant_coupon", 0))
 
     total = price - coupon
-    if shipping_days is not None:
+    if shipping_days is not None and not subscription:
         total += FIXED_SHIPPING
 
     return total
@@ -52,7 +54,13 @@ def normalize(raw: OfferRaw) -> OfferNormalized:
     else:
         external_id = market_id(str(raw.url))
 
-    price_final = compute_final_price(raw.price, raw.promo_flags, raw.shipping_days)
+    price_final = compute_final_price(
+        raw.price,
+        raw.promo_flags,
+        raw.shipping_days,
+        raw.subscription,
+        raw.price_in_cart,
+    )
 
     return OfferNormalized(
         source=raw.source,

--- a/app/scraper/adapters/market.py
+++ b/app/scraper/adapters/market.py
@@ -4,7 +4,42 @@ import re
 from ...schemas import OfferRaw
 from . import get_selectors
 
+GEOID_TO_CITY = {
+    "213": "Москва",
+    "2": "Санкт-Петербург",
+}
+
 BASE = "https://market.yandex.ru"
+
+
+def region_cookies(geoid: str) -> list[dict[str, str]]:
+    """Возвращает куки для выбора региона."""
+    return [
+        {
+            "name": "yandex_gid",
+            "value": geoid,
+            "domain": ".yandex.ru",
+            "path": "/",
+        }
+    ]
+
+
+def city_from_html(html: str) -> str | None:
+    """Извлекает название города из HTML шапки сайта."""
+    soup = BeautifulSoup(html, "html.parser")
+    el = soup.select_one("[data-autotest-id='region']") or soup.select_one(
+        "[data-zone-name='region']"
+    )
+    return el.get_text(strip=True) if el else None
+
+
+def ensure_region(html: str, geoid: str) -> bool:
+    """Проверяет, что отображаемый город соответствует geoid."""
+    expected = GEOID_TO_CITY.get(geoid)
+    if not expected:
+        return True
+    city = city_from_html(html)
+    return city == expected
 
 def parse_listing(html: str, geoid: str | None = None) -> list[OfferRaw]:
     """

--- a/tests/fixtures/market_region_msk.html
+++ b/tests/fixtures/market_region_msk.html
@@ -1,0 +1,1 @@
+<html><body><span data-autotest-id="region">Москва</span></body></html>

--- a/tests/fixtures/market_region_spb.html
+++ b/tests/fixtures/market_region_spb.html
@@ -1,0 +1,1 @@
+<html><body><span data-autotest-id="region">Санкт-Петербург</span></body></html>

--- a/tests/fixtures/ozon_region_msk.html
+++ b/tests/fixtures/ozon_region_msk.html
@@ -1,0 +1,1 @@
+<html><body><div data-widget="headerLocation">Москва</div></body></html>

--- a/tests/fixtures/ozon_region_spb.html
+++ b/tests/fixtures/ozon_region_spb.html
@@ -1,0 +1,1 @@
+<html><body><div data-widget="headerLocation">Санкт-Петербург</div></body></html>

--- a/tests/test_compute_final_price.py
+++ b/tests/test_compute_final_price.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.processing.normalize import compute_final_price, FIXED_SHIPPING
+
+
+def test_compute_final_price_with_coupon_and_shipping():
+    total = compute_final_price(1000, {"instant_coupon": 100}, shipping_days=3)
+    assert total == 1000 - 100 + FIXED_SHIPPING
+
+
+def test_compute_final_price_with_subscription():
+    total = compute_final_price(1000, shipping_days=5, subscription=True)
+    assert total == 1000
+
+
+def test_compute_final_price_price_in_cart():
+    total = compute_final_price(1000, price_in_cart=True)
+    assert total is None

--- a/tests/test_region_city.py
+++ b/tests/test_region_city.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.scraper.adapters import ozon, market
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def load(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def test_market_region_parsing():
+    html_msk = load("market_region_msk.html")
+    html_spb = load("market_region_spb.html")
+    assert market.city_from_html(html_msk) == "Москва"
+    assert market.city_from_html(html_spb) == "Санкт-Петербург"
+    assert market.ensure_region(html_msk, "213")
+    assert market.ensure_region(html_spb, "2")
+
+
+def test_ozon_region_parsing():
+    html_msk = load("ozon_region_msk.html")
+    html_spb = load("ozon_region_spb.html")
+    assert ozon.city_from_html(html_msk) == "Москва"
+    assert ozon.city_from_html(html_spb) == "Санкт-Петербург"
+    assert ozon.ensure_region(html_msk, "213")
+    assert ozon.ensure_region(html_spb, "2")


### PR DESCRIPTION
## Изменения
- выбор региона для Market и Ozon через куки и проверка города
- учёт подписки, доставки и корзины в финальной цене
- тесты на регионы и расчёт итоговой цены

## Тестирование
- `pytest`

