### PR TITLE
feat: apply user-specific filters in worker

### DIFF
--- a/app/worker.py
+++ b/app/worker.py
@@ -1,10 +1,13 @@
 import asyncio
+from sqlalchemy import select
+
 from .queue import RedisQueue, PermanentError
 from .processing.pipeline import process_preset
 from .scraper.render import RenderService
 from .db import SessionLocal
 from .config import settings
 from .notifier.bot import send_batch
+from .models import User
 
 import sentry_sdk
 from prometheus_client import start_http_server
@@ -24,15 +27,31 @@ class Worker:
         if site not in {"ozon", "market"}:
             raise PermanentError(f"Unknown site {site}")
         async with SessionLocal() as session:
+            min_discount = int(task.get("min_discount", settings.MIN_DISCOUNT))
+            min_score = int(task.get("min_score", settings.MIN_SCORE))
+            weights = task.get("weights")
+            geoid = task.get("geoid") or None
+
+            chat_id = task.get("chat_id")
+            if chat_id:
+                res = await session.execute(select(User).where(User.chat_id == int(chat_id)))
+                user = res.scalar_one_or_none()
+                if user:
+                    geoid = geoid or user.geoid
+                    min_discount = user.min_discount or min_discount
+                    min_score = user.min_score or min_score
+                    if user.score_weights_json:
+                        weights = user.score_weights_json
+
             results = await process_preset(
                 session,
                 self.render,
                 site,
                 task.get("url", ""),
-                task.get("geoid") or None,
-                int(task.get("min_discount", settings.MIN_DISCOUNT)),
-                int(task.get("min_score", settings.MIN_SCORE)),
-                task.get("weights"),
+                geoid,
+                min_discount,
+                min_score,
+                weights,
             )
         notify = task.get("notify") in {"True", True}
         if notify and settings.TG_CHAT_ID and results:


### PR DESCRIPTION
## Summary
- respect user region, thresholds, weights in worker when task specifies chat_id

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab407b2890833284ea3cab1e3ee673