### PR TITLE
Добавлены метрики по категориям и уведомления о выбросах

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,9 @@ load_secrets()
 class Settings(BaseSettings):
     TELEGRAM_BOT_TOKEN: str
     TG_CHAT_ID: int | None = None
+    MONITORING_SLACK_WEBHOOK: str | None = None
+    MONITORING_TELEGRAM_TOKEN: str | None = None
+    MONITORING_TELEGRAM_CHAT_ID: int | None = None
 
     PROXY_URL: str | None = None
     DATA_ENCRYPTION_KEY: str

--- a/app/notifier/monitoring.py
+++ b/app/notifier/monitoring.py
@@ -1,0 +1,36 @@
+import json
+import urllib.request
+from typing import Optional
+
+from ..config import settings
+
+
+def _post(url: str, payload: dict) -> None:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
+    try:
+        urllib.request.urlopen(req, timeout=5)
+    except Exception:
+        pass
+
+
+def notify_slack(text: str) -> None:
+    webhook: Optional[str] = getattr(settings, "MONITORING_SLACK_WEBHOOK", None)
+    if webhook:
+        _post(webhook, {"text": text})
+
+
+def notify_telegram(text: str) -> None:
+    token: Optional[str] = getattr(settings, "MONITORING_TELEGRAM_TOKEN", None)
+    chat_id: Optional[int] = getattr(settings, "MONITORING_TELEGRAM_CHAT_ID", None)
+    if token and chat_id:
+        url = f"https://api.telegram.org/bot{token}/sendMessage"
+        _post(url, {"chat_id": chat_id, "text": text})
+
+
+def notify_monitoring(text: str) -> None:
+    """Отправляет сообщение в каналы мониторинга."""
+    notify_slack(text)
+    notify_telegram(text)

--- a/app/processing/pipeline.py
+++ b/app/processing/pipeline.py
@@ -15,7 +15,11 @@ from ..processing.detectors import is_fake_msrp
 from ..processing.dedupe import dedupe_offers
 from ..models import Product, Offer, PriceHistory
 from ..config import settings
-from ..metrics import update_listing_stats, render_errors
+from ..metrics import (
+    update_listing_stats,
+    update_category_price_stats,
+    render_errors,
+)
 
 async def fetch_site_list(
     render: RenderService, site: str, url: str, geoid: str | None
@@ -172,6 +176,7 @@ async def process_preset(
     raws = await fetch_site_list(render, site, url, geoid)
     normalized = [normalize(r) for r in raws]
     normalized = dedupe_offers(normalized)
+    update_category_price_stats(normalized)
 
     results: list[dict] = []
     infos = []

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -44,6 +44,7 @@ def load_pipeline(monkeypatch):
         "app.metrics",
         types.SimpleNamespace(
             update_listing_stats=lambda *a, **k: None,
+            update_category_price_stats=lambda *a, **k: None,
             render_errors=types.SimpleNamespace(labels=lambda **kw: types.SimpleNamespace(inc=lambda: None)),
         ),
     )

--- a/tests/test_metrics_category.py
+++ b/tests/test_metrics_category.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+# Ensure required environment variables for settings
+import os
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test")
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.schemas import OfferNormalized
+import app.metrics as metrics
+
+
+def make_item(price, category="cat"):
+    return OfferNormalized(
+        source="ozon",
+        external_id=str(price or "x"),
+        title="t",
+        url=f"https://ex.com/{price}",
+        finger=str(price or "x"),
+        price=price,
+        category=category,
+    )
+
+
+def test_category_metrics_and_trigger(monkeypatch):
+    messages = []
+    monkeypatch.setattr(metrics, "notify_monitoring", lambda m: messages.append(m))
+
+    metrics._category_counts.clear()
+    metrics.category_avg_price.labels(category="cat").set(0)
+    metrics.category_no_price_share.labels(category="cat").set(0)
+
+    items = [
+        make_item(100),
+        make_item(200),
+        make_item(300),
+        make_item(None),
+    ]
+    metrics.update_category_price_stats(items)
+
+    assert metrics.category_avg_price.labels(category="cat")._value.get() == 200
+    assert metrics.category_no_price_share.labels(category="cat")._value.get() == 0.25
+
+    items2 = [make_item(150)]
+    metrics.update_category_price_stats(items2)
+    assert messages, "должно сработать уведомление о падении выборки"


### PR DESCRIPTION
## Описание
- отслеживание средней цены и доли карточек без цены по категориям
- уведомления в Slack/Telegram при резком изменении количества карточек

## Тестирование
- `pytest -q`

