### PR TITLE
Перевод очереди на consumer groups и обработка DLQ

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -44,6 +44,7 @@ class Settings(BaseSettings):
 
     METRICS_PORT: int = 8000
     SENTRY_DSN: str | None = None
+    DLQ_OVERFLOW_THRESHOLD: int = 100
 
     model_config = SettingsConfigDict(env_file='.env', extra='ignore')
 

--- a/app/dlq_worker.py
+++ b/app/dlq_worker.py
@@ -1,0 +1,36 @@
+import asyncio
+import logging
+
+from prometheus_client import start_http_server
+
+from .queue import RedisQueue
+from .config import settings
+from .logging_config import setup_logging
+
+
+logger = logging.getLogger(__name__)
+
+
+class DLQWorker:
+    def __init__(self, queue: RedisQueue):
+        self.queue = queue
+
+    async def start(self) -> None:
+        await self.queue.consume_dlq(self.handle_task)
+
+    async def handle_task(self, task: dict) -> None:
+        logger.info("DLQ task: %s", task)
+
+
+async def main() -> None:
+    setup_logging()
+    if settings.METRICS_PORT:
+        start_http_server(settings.METRICS_PORT)
+    queue = RedisQueue(settings.REDIS_URL, settings.QUEUE_STREAM)
+    worker = DLQWorker(queue)
+    await worker.start()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -13,6 +13,12 @@ render_latency = Histogram(
 render_errors = Counter(
     "render_errors_total", "Total render errors", ["domain"]
 )
+dlq_tasks_total = Counter(
+    "dlq_tasks_total", "Total tasks processed from DLQ"
+)
+dlq_backlog = Gauge(
+    "dlq_backlog", "Current number of tasks in DLQ"
+)
 _listing_total = defaultdict(int)
 _listing_empty = defaultdict(int)
 listing_empty_share = Gauge(

--- a/app/queue/__init__.py
+++ b/app/queue/__init__.py
@@ -1,7 +1,9 @@
 import asyncio
 import random
 from typing import Callable, Awaitable, Any
+
 import redis.asyncio as redis
+from redis.exceptions import ResponseError
 
 
 class PermanentError(Exception):
@@ -22,18 +24,45 @@ class RedisQueue(AbstractQueue):
         self.redis = redis.from_url(url)
         self.stream = stream
         self.dlq_stream = f"{stream}:dlq"
-        self.last_id = "0-0"
+        self.group = f"{stream}:group"
+        self.dlq_group = f"{self.dlq_stream}:group"
+        self.idempotency_ttl = 24 * 3600
+
+    async def _ensure_group(self, stream: str, group: str) -> None:
+        """Создаёт consumer group, если она ещё не существует."""
+        try:
+            await self.redis.xgroup_create(stream, group, id="$", mkstream=True)
+        except ResponseError as e:
+            if "BUSYGROUP" not in str(e):
+                raise
 
     async def publish(self, data: dict, dlq: bool = False) -> None:
         stream = self.dlq_stream if dlq else self.stream
-        # redis streams хранят строки
+        group = self.dlq_group if dlq else self.group
+        await self._ensure_group(stream, group)
+
+        site = data.get("site")
+        url = data.get("url")
+        page = data.get("page")
+        geoid = data.get("geoid")
+        idem_key = f"{site}:{url}:{page}:{geoid}"
+        idem_redis_key = f"{stream}:idem:{idem_key}"
+        added = await self.redis.setnx(idem_redis_key, 1)
+        if not added:
+            return
+        await self.redis.expire(idem_redis_key, self.idempotency_ttl)
+
         payload = {k: str(v) for k, v in data.items()}
+        payload["idempotency_key"] = idem_key
         await self.redis.xadd(stream, payload)
 
     async def consume(self, handler: Callable[[dict], Awaitable[Any]], consumer_name: str = "worker") -> None:
+        await self._ensure_group(self.stream, self.group)
         max_retries = 5
         while True:
-            res = await self.redis.xread({self.stream: self.last_id}, block=1000, count=1)
+            res = await self.redis.xreadgroup(
+                self.group, consumer_name, {self.stream: ">"}, count=1, block=1000
+            )
             if not res:
                 continue
             for _stream, messages in res:
@@ -55,5 +84,41 @@ class RedisQueue(AbstractQueue):
                             await asyncio.sleep(backoff)
                             await self.publish({**data, "retries": retries + 1})
                     finally:
+                        await self.redis.xack(self.stream, self.group, msg_id)
                         await self.redis.xdel(self.stream, msg_id)
-                        self.last_id = msg_id
+
+    async def consume_dlq(
+        self,
+        handler: Callable[[dict], Awaitable[Any]],
+        consumer_name: str = "dlq",
+    ) -> None:
+        from ..metrics import dlq_tasks_total, dlq_backlog
+        from ..config import settings
+        from ..notifier.monitoring import notify_monitoring
+
+        await self._ensure_group(self.dlq_stream, self.dlq_group)
+        threshold = getattr(settings, "DLQ_OVERFLOW_THRESHOLD", 100)
+
+        while True:
+            res = await self.redis.xreadgroup(
+                self.dlq_group, consumer_name, {self.dlq_stream: ">"}, count=1, block=1000
+            )
+            if not res:
+                backlog = await self.redis.xlen(self.dlq_stream)
+                dlq_backlog.set(backlog)
+                if backlog > threshold:
+                    notify_monitoring(f"DLQ overflow: {backlog} messages")
+                continue
+            for _stream, messages in res:
+                for msg_id, message in messages:
+                    data = {k.decode(): v.decode() for k, v in message.items()}
+                    try:
+                        await handler(data)
+                    finally:
+                        dlq_tasks_total.inc()
+                        await self.redis.xack(self.dlq_stream, self.dlq_group, msg_id)
+                        await self.redis.xdel(self.dlq_stream, msg_id)
+                        backlog = await self.redis.xlen(self.dlq_stream)
+                        dlq_backlog.set(backlog)
+                        if backlog > threshold:
+                            notify_monitoring(f"DLQ overflow: {backlog} messages")


### PR DESCRIPTION
## Summary
- Переписан RedisQueue на consumer groups с явным XACK и идемпотентными публикациями
- Добавлены метрики и обработчик для DLQ с алертом при переполнении
- Добавлен отдельный воркер для чтения очереди DLQ

## Testing
- `pytest -q`

