### PR TITLE
Перенесён расчёт финальной цены в общий модуль

### DIFF
--- a/app/pricing.py
+++ b/app/pricing.py
@@ -1,0 +1,29 @@
+"""Расчёт финальной цены товаров."""
+from typing import Optional, Dict
+
+FIXED_SHIPPING = 199
+
+
+def compute_final_price(
+    price: Optional[int],
+    promo_flags: Dict[str, int | bool] | None = None,
+    shipping_days: Optional[int] = None,
+    subscription: bool = False,
+    price_in_cart: bool = False,
+) -> Optional[int]:
+    """Высчитывает финальную цену с учётом купонов, доставки и подписки."""
+
+    if price is None or price_in_cart:
+        return None
+
+    coupon = 0
+    if promo_flags and isinstance(promo_flags.get("instant_coupon"), int):
+        coupon = int(promo_flags.get("instant_coupon", 0))
+
+    total = price - coupon
+    if shipping_days is not None and not subscription:
+        total += FIXED_SHIPPING
+
+    return total
+
+__all__ = ["compute_final_price", "FIXED_SHIPPING"]

--- a/app/processing/normalize.py
+++ b/app/processing/normalize.py
@@ -1,9 +1,10 @@
 import hashlib
 import re
-from typing import Optional, Dict
+from typing import Optional
 from ..schemas import OfferRaw, OfferNormalized
 from ..scraper.adapters.ozon import external_id_from_url as ozon_id
 from ..scraper.adapters.market import external_id_from_url as market_id
+from ..pricing import compute_final_price
 
 def norm_title(t: str) -> str:
     return re.sub(r"\s+", " ", t).strip()
@@ -21,30 +22,6 @@ def guess_brand(title: str) -> Optional[str]:
             return k.capitalize()
     return None
 
-FIXED_SHIPPING = 199
-
-
-def compute_final_price(
-    price: Optional[int],
-    promo_flags: Dict[str, int | bool] | None = None,
-    shipping_days: Optional[int] = None,
-    subscription: bool = False,
-    price_in_cart: bool = False,
-) -> Optional[int]:
-    """Высчитывает финальную цену с учётом купонов, доставки и подписки."""
-
-    if price is None or price_in_cart:
-        return None
-
-    coupon = 0
-    if promo_flags and isinstance(promo_flags.get("instant_coupon"), int):
-        coupon = int(promo_flags.get("instant_coupon", 0))
-
-    total = price - coupon
-    if shipping_days is not None and not subscription:
-        total += FIXED_SHIPPING
-
-    return total
 
 def normalize(raw: OfferRaw) -> OfferNormalized:
     title = norm_title(raw.title)

--- a/app/scraper/adapters/market.py
+++ b/app/scraper/adapters/market.py
@@ -2,6 +2,7 @@ from bs4 import BeautifulSoup
 from urllib.parse import urljoin, urlparse
 import re
 from ...schemas import OfferRaw
+from ...pricing import compute_final_price as compute_final_price_common
 from . import get_selectors, select_one, select_all
 
 GEOID_TO_CITY = {
@@ -175,23 +176,15 @@ def parse_product(html: str, geoid: str | None = None) -> OfferRaw:
     return offer
 
 
-FIXED_SHIPPING = 199
-
-
 def compute_final_price(offer: OfferRaw):
-    """Считает финальную цену оффера."""
-    if offer.price is None or offer.price_in_cart:
-        return None
-
-    coupon = 0
-    if offer.promo_flags and isinstance(offer.promo_flags.get("instant_coupon"), int):
-        coupon = int(offer.promo_flags["instant_coupon"])
-
-    total = offer.price - coupon
-    if offer.shipping_days is not None and not offer.subscription:
-        total += FIXED_SHIPPING
-
-    return total
+    """Считает финальную цену оффера, используя общий модуль."""
+    return compute_final_price_common(
+        offer.price,
+        offer.promo_flags,
+        offer.shipping_days,
+        offer.subscription,
+        offer.price_in_cart,
+    )
 
 def external_id_from_url(url: str) -> str:
     # market product URLs look like /product--slug/ID?...

--- a/app/scraper/adapters/ozon.py
+++ b/app/scraper/adapters/ozon.py
@@ -2,6 +2,7 @@ from bs4 import BeautifulSoup
 from urllib.parse import urljoin, urlparse
 import re
 from ...schemas import OfferRaw
+from ...pricing import compute_final_price as compute_final_price_common
 from . import get_selectors, select_one, select_all
 
 GEOID_TO_CITY = {
@@ -179,23 +180,15 @@ def parse_product(html: str) -> OfferRaw:
     return offer
 
 
-FIXED_SHIPPING = 199
-
-
 def compute_final_price(offer: OfferRaw):
-    """Считает финальную цену оффера."""
-    if offer.price is None or offer.price_in_cart:
-        return None
-
-    coupon = 0
-    if offer.promo_flags and isinstance(offer.promo_flags.get("instant_coupon"), int):
-        coupon = int(offer.promo_flags["instant_coupon"])
-
-    total = offer.price - coupon
-    if offer.shipping_days is not None and not offer.subscription:
-        total += FIXED_SHIPPING
-
-    return total
+    """Считает финальную цену оффера, используя общий модуль."""
+    return compute_final_price_common(
+        offer.price,
+        offer.promo_flags,
+        offer.shipping_days,
+        offer.subscription,
+        offer.price_in_cart,
+    )
 
 def external_id_from_url(url: str) -> str:
     # пример: https://www.ozon.ru/product/slug-123456789/ → берём последний числовой id

--- a/tests/test_compute_final_price.py
+++ b/tests/test_compute_final_price.py
@@ -5,7 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from app.processing.normalize import compute_final_price, FIXED_SHIPPING
+from app.pricing import compute_final_price, FIXED_SHIPPING
 
 
 def test_compute_final_price_with_coupon_and_shipping():


### PR DESCRIPTION
## Summary
- вынесена функция `compute_final_price` в `app/pricing.py`
- адаптеры Ozon и Market используют общий расчёт и больше не содержат константу `FIXED_SHIPPING`
- `normalize` и тесты обновлены под новый модуль

## Testing
- `pytest -q`
