### PR TITLE
feat: вынести стоимость доставки в настройки

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -27,6 +27,8 @@ class Settings(BaseSettings):
     MIN_SCORE: int = 70
     DAILY_MSG_LIMIT: int = 20
 
+    SHIPPING_COST: int = 199
+
     BUDGET_MAX_PAGES: int = 100
     BUDGET_MAX_TASKS: int = 20
     QUIET_HOURS: str | None = None

--- a/app/pricing.py
+++ b/app/pricing.py
@@ -1,7 +1,7 @@
 """Расчёт финальной цены товаров."""
 from typing import Optional, Dict
 
-FIXED_SHIPPING = 199
+from .config import settings
 
 
 def compute_final_price(
@@ -22,8 +22,8 @@ def compute_final_price(
 
     total = price - coupon
     if shipping_days is not None and not subscription:
-        total += FIXED_SHIPPING
+        total += settings.SHIPPING_COST
 
     return total
 
-__all__ = ["compute_final_price", "FIXED_SHIPPING"]
+__all__ = ["compute_final_price"]

--- a/tests/test_compute_final_price.py
+++ b/tests/test_compute_final_price.py
@@ -1,19 +1,24 @@
 from pathlib import Path
 import sys
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from app.pricing import compute_final_price, FIXED_SHIPPING
+from app.pricing import compute_final_price
+from app.config import settings
 
 
-def test_compute_final_price_with_coupon_and_shipping():
+@pytest.mark.parametrize("shipping_cost", [199, 350])
+def test_compute_final_price_with_coupon_and_shipping(monkeypatch, shipping_cost):
+    monkeypatch.setattr(settings, "SHIPPING_COST", shipping_cost)
     total = compute_final_price(1000, {"instant_coupon": 100}, shipping_days=3)
-    assert total == 1000 - 100 + FIXED_SHIPPING
+    assert total == 1000 - 100 + shipping_cost
 
 
-def test_compute_final_price_with_subscription():
+def test_compute_final_price_with_subscription(monkeypatch):
+    monkeypatch.setattr(settings, "SHIPPING_COST", 250)
     total = compute_final_price(1000, shipping_days=5, subscription=True)
     assert total == 1000
 
@@ -21,3 +26,4 @@ def test_compute_final_price_with_subscription():
 def test_compute_final_price_price_in_cart():
     total = compute_final_price(1000, price_in_cart=True)
     assert total is None
+


### PR DESCRIPTION
## Summary
- add configurable SHIPPING_COST in settings
- use settings.SHIPPING_COST when computing final price
- test different shipping tariffs

## Testing
- `pytest tests/test_compute_final_price.py -q`

