### PR TITLE
feat: логирование пропусков селекторов

### DIFF
--- a/app/scraper/__init__.py
+++ b/app/scraper/__init__.py
@@ -1,0 +1,5 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["logger"]


### PR DESCRIPTION
## Summary
- логировать пропуски ссылок и цен в адаптерах Ozon и Market
- добавить общий логгер для `scraper`
- покрыть предупреждения тестами

## Testing
- `python -m pytest -q`

