### PR TITLE
Добавлен модуль render_pool с кэшем и диагностикой

### DIFF
--- a/render_pool/cache.py
+++ b/render_pool/cache.py
@@ -1,0 +1,34 @@
+import random
+import time
+from typing import Any, Dict, Tuple
+
+
+class ListingTTLCache:
+    """Простой TTL-кэш для HTML листингов по URL."""
+
+    def __init__(self, ttl_min: int = 30, ttl_max: int = 180) -> None:
+        if ttl_min > ttl_max:
+            raise ValueError("ttl_min должен быть меньше или равен ttl_max")
+        self.ttl_min = ttl_min
+        self.ttl_max = ttl_max
+        self._store: Dict[str, Tuple[Any, float]] = {}
+
+    def get(self, url: str) -> Any | None:
+        """Возвращает значение из кэша, если оно не просрочено."""
+        entry = self._store.get(url)
+        if not entry:
+            return None
+        value, expires_at = entry
+        if expires_at < time.time():
+            del self._store[url]
+            return None
+        return value
+
+    def set(self, url: str, value: Any) -> None:
+        """Сохраняет значение в кэш с произвольным TTL."""
+        ttl = random.randint(self.ttl_min, self.ttl_max)
+        self._store[url] = (value, time.time() + ttl)
+
+    def clear(self) -> None:
+        """Очищает кэш."""
+        self._store.clear()

--- a/render_pool/context.py
+++ b/render_pool/context.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from typing import List, Dict
+
+from app.scraper.adapters import market, ozon
+
+
+@dataclass
+class RenderContext:
+    """Контекст рендера с регионом и куками."""
+
+    geoid: str
+    cookies: List[Dict[str, str]]
+
+
+def create(geoid: str) -> RenderContext:
+    """Создаёт контекст, устанавливая yandex_gid и регион Ozon."""
+    cookies = market.region_cookies(geoid) + ozon.region_cookies(geoid)
+    return RenderContext(geoid=geoid, cookies=cookies)

--- a/render_pool/diagnostics.py
+++ b/render_pool/diagnostics.py
@@ -1,0 +1,18 @@
+import uuid
+from datetime import datetime
+from typing import Optional
+
+import boto3
+
+
+def save_error(url: str, html: str, screenshot: Optional[bytes], bucket: str, s3_client=None) -> str:
+    """Сохраняет HTML и скриншот в S3, возвращая базовое имя файлов."""
+    s3 = s3_client or boto3.client("s3")
+    ts = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+    base = f"{ts}_{uuid.uuid4().hex}"
+    s3.put_object(Bucket=bucket, Key=f"{base}.html", Body=html.encode("utf-8"), ContentType="text/html")
+    if screenshot:
+        s3.put_object(
+            Bucket=bucket, Key=f"{base}.png", Body=screenshot, ContentType="image/png"
+        )
+    return base

--- a/tests/test_render_pool.py
+++ b/tests/test_render_pool.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import time
+
+import boto3
+from botocore.stub import Stubber, ANY
+
+from render_pool.cache import ListingTTLCache
+from render_pool.context import create
+from render_pool.diagnostics import save_error
+
+
+def test_ttl_cache_expiration():
+    cache = ListingTTLCache(ttl_min=1, ttl_max=1)
+    cache.set("url", "data")
+    assert cache.get("url") == "data"
+    time.sleep(1.2)
+    assert cache.get("url") is None
+
+
+def test_context_sets_cookies():
+    ctx = create("213")
+    names = {c["name"] for c in ctx.cookies}
+    assert "yandex_gid" in names
+    assert "region" in names
+
+
+def test_diagnostics_saves_to_s3():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    stubber = Stubber(s3)
+    bucket = "test-bucket"
+    stubber.add_response(
+        "put_object",
+        {},
+        {
+            "Bucket": bucket,
+            "Key": ANY,
+            "Body": b"<html>",
+            "ContentType": "text/html",
+        },
+    )
+    stubber.add_response(
+        "put_object",
+        {},
+        {
+            "Bucket": bucket,
+            "Key": ANY,
+            "Body": b"img",
+            "ContentType": "image/png",
+        },
+    )
+    stubber.activate()
+    save_error("http://example.com", "<html>", b"img", bucket, s3_client=s3)
+    stubber.deactivate()


### PR DESCRIPTION
## Изменения
- TTL-кэш листингов с случайным сроком жизни
- Формирование контекста с установкой yandex_gid и региона Ozon
- Сохранение HTML и скриншотов ошибок в S3

## Тестирование
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab6b9593c08332998a05510d65302f